### PR TITLE
Grid#advance() optimising rd 2

### DIFF
--- a/src/data/cell.rs
+++ b/src/data/cell.rs
@@ -16,11 +16,12 @@ impl Cell {
 
     // Update alive status based on neighbour count
     // https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life#Rules
-    pub fn update(&mut self, neighbours_cnt: usize) -> () {
-        self.0 = self.next_status(neighbours_cnt)
+    pub fn update(&mut self, status: Status) -> () {
+        self.0 = status
     }
 
-    fn next_status(&self, neighbours_cnt: usize) -> Status {
+    // Returns the next status given a number of neighbours
+    pub fn next_status(&self, neighbours_cnt: usize) -> Status {
         match (&self.0, neighbours_cnt) {
             (_, 3) => Status::Alive,
             (&Status::Alive, 2) => Status::Alive,

--- a/src/data/grid.rs
+++ b/src/data/grid.rs
@@ -2,6 +2,7 @@ use data::cell::{Cell, Status};
 use rand;
 use rand::Rng;
 use rayon::prelude::*;
+use std::mem;
 
 pub const PAR_THRESHOLD_AREA: usize = 250000;
 const PAR_THRESHOLD_LENGTH: usize = 25000;
@@ -20,23 +21,20 @@ pub struct Grid {
      * [ (2,0) (2,1) (2,2) ]
      */
     cells: Vec<Vec<Cell>>,
+    scratchpad_cells: Vec<Vec<Cell>>,
     max_i: usize,
     max_j: usize,
     area: usize,
-    neighbours: Vec<Vec<[Coord; 8]>>, // Cache of where the neighbours are for each point
-    coords_with_neighbours: Vec<CoordNeighbours>, // Optimisation for single-threaded updating
+    // Cache of where the neighbours are for each point
+    neighbours: Vec<Vec<[Coord; 8]>>,
+    // Cache of Grid (i,j) assuming grid is flattened row by row from left to right
+    coords: Vec<Coord>,
 }
 
 #[derive(PartialEq, Eq, Debug, PartialOrd, Ord, Clone)]
 struct Coord {
     i: usize,
     j: usize,
-}
-
-#[derive(PartialEq, Eq, Debug)]
-struct CoordNeighbours {
-    coord: Coord,
-    neighbours: [Coord; 8],
 }
 
 impl Grid {
@@ -57,16 +55,18 @@ impl Grid {
             }
             cells.push(columns);
         }
+        let scratchpad_cells = cells.clone();
         let (max_i, max_j) = max_coordinates(&cells);
         let neighbours = neighbours(max_i, max_j, &cells);
-        let coords_with_neighbours = coords_with_neighbours(max_i, max_j, &cells);
+        let coords = coords(&cells);
         let area = width * height;
         Grid {
             cells,
+            scratchpad_cells,
             max_i,
             max_j,
             area,
-            coords_with_neighbours,
+            coords,
             neighbours,
         }
     }
@@ -76,9 +76,9 @@ impl Grid {
     ///
     /// TODO: is using iter faster or slower than just doing the checks?
     pub fn get_idx(&self, &GridIdx(idx): &GridIdx) -> Option<&Cell> {
-        if idx < self.coords_with_neighbours.len() {
-            let coord_with_n = &self.coords_with_neighbours[idx];
-            Some(&self.cells[coord_with_n.coord.i][coord_with_n.coord.j])
+        if idx < self.coords.len() {
+            let coord = &self.coords[idx];
+            Some(&self.cells[coord.i][coord.j])
         } else {
             None
         }
@@ -102,10 +102,12 @@ impl Grid {
     }
 
     pub fn advance(&mut self) -> () {
-        if self.area() >= PAR_THRESHOLD_AREA {
+        {
             let neighbours = &self.neighbours;
-            let last_gen = &self.cells.clone();
-            let cells = &mut self.cells;
+            let last_gen = &self.cells;
+            let area_requires_par = self.area() >= PAR_THRESHOLD_AREA;
+            let width_requires_par = self.width() >= PAR_THRESHOLD_LENGTH;
+            let cells = &mut self.scratchpad_cells;
             let cell_op = |(i, j, cell): (usize, usize, &mut Cell)| {
                 let alives = neighbours[i][j]
                     .iter()
@@ -115,69 +117,45 @@ impl Grid {
                           } else {
                               acc
                           });
-                cell.update(alives);
+                let next_status = last_gen[i][j].next_status(alives);
+                cell.update(next_status);
             };
-            cells
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(i, row)| if row.len() >= PAR_THRESHOLD_LENGTH {
-                              row.par_iter_mut()
-                                  .enumerate()
-                                  .for_each(|(j, cell)| cell_op((i, j, cell)))
-                          } else {
-                              for (j, cell) in row.iter_mut().enumerate() {
-                                  cell_op((i, j, cell))
-                              }
-                          })
-        } else {
-            self.advance_single_thread();
-        }
-    }
-
-    // Single-threaded version of advancing the grid; the advantage of this is
-    // that it does not clone the original cells.
-    fn advance_single_thread(&mut self) -> () {
-        let alive_counts: Vec<(&Coord, usize)> = {
-            let cells = &self.cells;
-            self.coords_with_neighbours
-                .iter()
-                .map(|&CoordNeighbours {
-                           ref coord,
-                           ref neighbours,
-                       }| {
-                    let alive_count = neighbours
-                        .iter()
-                        .fold(0,
-                              |acc, &Coord { i, j }| if cells[i][j].0 == Status::Alive {
-                                  acc + 1
+            let non_par_row_op = |(i, row): (usize, &mut Vec<Cell>)| for (j, cell) in
+                row.iter_mut().enumerate() {
+                cell_op((i, j, cell))
+            };
+            if area_requires_par {
+                cells
+                    .par_iter_mut()
+                    .enumerate()
+                    .for_each(|(i, row)| if width_requires_par {
+                                  row.par_iter_mut()
+                                      .enumerate()
+                                      .for_each(|(j, cell)| cell_op((i, j, cell)))
                               } else {
-                                  acc
+                                  non_par_row_op((i, row))
                               });
-                    (coord, alive_count)
-                })
-                .collect()
-        };
-        for (coord, alives) in alive_counts {
-            self.cells[coord.i][coord.j].update(alives)
+            } else {
+                for (i, row) in cells.iter_mut().enumerate() {
+                    non_par_row_op((i, row))
+                }
+            }
         }
+        mem::swap(&mut self.cells, &mut self.scratchpad_cells);
     }
 }
 
-fn coords_with_neighbours(max_i: usize, max_j: usize, cells: &[Vec<Cell>]) -> Vec<CoordNeighbours> {
+fn coords(cells: &[Vec<Cell>]) -> Vec<Coord> {
     cells
         .iter()
         .enumerate()
         .flat_map(|(i, row)| {
-            let v: Vec<CoordNeighbours> = row.iter()
-                .enumerate()
-                .map(|(j, _)| {
-                         let coord = Coord { i, j };
-                         let neighbours = neighbour_coords(max_i, max_j, &coord);
-                         CoordNeighbours { coord, neighbours }
-                     })
-                .collect();
-            v
-        })
+                      let v: Vec<Coord> = row.iter()
+                          .enumerate()
+                          .map(|(j, _)| Coord { i, j })
+                          .collect();
+                      v
+                  })
         .collect()
 }
 


### PR DESCRIPTION
Make use of the awesome mem::swap method to keep cloning to a minimum:
when the grid is created.

On each advancement, make use of the new scratchpad field to do mutations
while referring to the current generation's data. When all ops are done,
simply swap the scratchpad field with the current gen field.