### PR TITLE
Feature/matrix flattening

### DIFF
--- a/src/data/grid.rs
+++ b/src/data/grid.rs
@@ -166,67 +166,66 @@ impl Grid {
 }
 
 fn neighbours(max_i: usize, max_j: usize, cells: &[Vec<Cell>]) -> Vec<[GridIdx; 8]> {
-    let neighbour_coords = |coord: &Coord| {
-        let width = max_j + 1;
-        let Coord { i, j } = *coord;
-        let to_grid_idx = |Coord { i, j }: Coord| GridIdx(width * i + j);
-
-        let i_up = match i {
-            0 => max_i,
-            _ => i - 1,
-        };
-
-        let i_down = match i {
-            _ if i == max_i => 0,
-            _ => i + 1,
-        };
-
-        let j_left = match j {
-            0 => max_j,
-            _ => j - 1,
-        };
-        let j_right = match j {
-            _ if j == max_j => 0,
-            _ => j + 1,
-        };
-
-        let north = Coord { i: i_up, j: j };
-        let north_east = Coord {
-            i: i_up,
-            j: j_right,
-        };
-        let east = Coord { i, j: j_right };
-        let south_east = Coord {
-            i: i_down,
-            j: j_right,
-        };
-        let south = Coord { i: i_down, j };
-        let south_west = Coord {
-            i: i_down,
-            j: j_left,
-        };
-        let west = Coord { i, j: j_left };
-        let north_west = Coord { i: i_up, j: j_left };
-        [to_grid_idx(north),
-         to_grid_idx(north_east),
-         to_grid_idx(east),
-         to_grid_idx(south_east),
-         to_grid_idx(south),
-         to_grid_idx(south_west),
-         to_grid_idx(west),
-         to_grid_idx(north_west)]
-    };
-
-
     let mut v = Vec::with_capacity((max_i + 1) * (max_j + 1));
     for (i, row) in cells.iter().enumerate() {
         for (j, _) in row.iter().enumerate() {
             let coord = Coord { i, j };
-            v.push(neighbour_coords(&coord))
+            v.push(neighbour_coords(max_i, max_j, &coord))
         }
 
     }
     v
+}
+
+fn neighbour_coords(max_i: usize, max_j: usize, coord: &Coord) -> [GridIdx; 8] {
+    let width = max_j + 1;
+    let Coord { i, j } = *coord;
+    let to_grid_idx = |Coord { i, j }: Coord| GridIdx(width * i + j);
+
+    let i_up = match i {
+        0 => max_i,
+        _ => i - 1,
+    };
+
+    let i_down = match i {
+        _ if i == max_i => 0,
+        _ => i + 1,
+    };
+
+    let j_left = match j {
+        0 => max_j,
+        _ => j - 1,
+    };
+    let j_right = match j {
+        _ if j == max_j => 0,
+        _ => j + 1,
+    };
+
+    let north = Coord { i: i_up, j: j };
+    let north_east = Coord {
+        i: i_up,
+        j: j_right,
+    };
+    let east = Coord { i, j: j_right };
+    let south_east = Coord {
+        i: i_down,
+        j: j_right,
+    };
+    let south = Coord { i: i_down, j };
+    let south_west = Coord {
+        i: i_down,
+        j: j_left,
+    };
+    let west = Coord { i, j: j_left };
+    let north_west = Coord { i: i_up, j: j_left };
+    [to_grid_idx(north),
+     to_grid_idx(north_east),
+     to_grid_idx(east),
+     to_grid_idx(south_east),
+     to_grid_idx(south),
+     to_grid_idx(south_west),
+     to_grid_idx(west),
+     to_grid_idx(north_west)]
 }
 
 

--- a/src/data/grid.rs
+++ b/src/data/grid.rs
@@ -8,7 +8,7 @@ pub const PAR_THRESHOLD_AREA: usize = 250000;
 const PAR_THRESHOLD_LENGTH: usize = 25000;
 
 /// Used for indexing into the grid
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GridIdx(pub usize);
 
 #[derive(Debug)]
@@ -79,6 +79,24 @@ impl Grid {
         if idx < self.coords.len() {
             let coord = &self.coords[idx];
             Some(&self.cells[coord.i][coord.j])
+        } else {
+            None
+        }
+    }
+
+    fn to_grid_idx(&self, &Coord { i, j }: &Coord) -> Option<GridIdx> {
+        if i <= self.max_i && j <= self.max_j {
+            Some(GridIdx(self.width() * i + j))
+        } else {
+            None
+        }
+    }
+
+    fn to_coord(&self, &GridIdx(idx): &GridIdx) -> Option<Coord> {
+        if idx < self.area() {
+            let i = idx / self.width();
+            let j = idx % self.width();
+            Some(Coord { i, j })
         } else {
             None
         }
@@ -322,6 +340,33 @@ mod tests {
             }
 
         }
+    }
+
+    /// Given
+    ///
+    /// [ (0,0) (0,1) (0,2) (0, 3) ]
+    /// [ (1,0) (1,1) (1,2) (1, 3) ]
+    /// [ (2,0) (2,1) (2,2) (2, 3) ]
+    #[test]
+    fn test_to_grid_idx() {
+        let grid = Grid::new(4, 3);
+        assert_eq!(grid.to_grid_idx(&Coord { i: 0, j: 0 }), Some(GridIdx(0)));
+        assert_eq!(grid.to_grid_idx(&Coord { i: 1, j: 2 }), Some(GridIdx(6)));
+        assert_eq!(grid.to_grid_idx(&Coord { i: 2, j: 3 }), Some(GridIdx(11)));
+        assert_eq!(grid.to_grid_idx(&Coord { i: 3, j: 3 }), None);
+    }
+    /// Given
+    ///
+    /// [ (0,0) (0,1) (0,2) (0, 3) ]
+    /// [ (1,0) (1,1) (1,2) (1, 3) ]
+    /// [ (2,0) (2,1) (2,2) (2, 3) ]
+    #[test]
+    fn test_to_coord() {
+        let grid = Grid::new(4, 3);
+        assert_eq!(grid.to_coord(&GridIdx(0)), Some(Coord { i: 0, j: 0 }));
+        assert_eq!(grid.to_coord(&GridIdx(6)), Some(Coord { i: 1, j: 2 }));
+        assert_eq!(grid.to_coord(&GridIdx(11)), Some(Coord { i: 2, j: 3 }));
+        assert_eq!(grid.to_coord(&GridIdx(12)), None);
     }
 
     fn alive_cells(grid: &Grid) -> Vec<Coord> {

--- a/src/data/grid.rs
+++ b/src/data/grid.rs
@@ -5,7 +5,6 @@ use rayon::prelude::*;
 use std::mem;
 
 pub const PAR_THRESHOLD_AREA: usize = 250000;
-const PAR_THRESHOLD_LENGTH: usize = 25000;
 
 /// Used for indexing into the grid
 #[derive(Debug, PartialEq, Eq)]
@@ -19,31 +18,32 @@ pub struct Grid {
      * [ (0,0) (0,1) (0,2) ]
      * [ (1,0) (1,1) (1,2) ]
      * [ (2,0) (2,1) (2,2) ]
+     *
+     * will get flattened into a single vector:
+     * [ (0,0), (0,1), (0,2), (1,0), (1,1), (1,2), (2,0), (2,1), (2,2) ]
      */
-    cells: Vec<Vec<Cell>>,
-    scratchpad_cells: Vec<Vec<Cell>>,
+    cells: Vec<Cell>,
+    scratchpad_cells: Vec<Cell>,
     max_i: usize,
     max_j: usize,
     area: usize,
     // Cache of where the neighbours are for each point
-    neighbours: Vec<Vec<[Coord; 8]>>,
-    // Cache of Grid (i,j) assuming grid is flattened row by row from left to right
-    coords: Vec<Coord>,
+    neighbours: Vec<[GridIdx; 8]>,
 }
 
 #[derive(PartialEq, Eq, Debug, PartialOrd, Ord, Clone)]
-struct Coord {
-    i: usize,
-    j: usize,
+pub struct Coord {
+    pub i: usize,
+    pub j: usize,
 }
 
 impl Grid {
     /// Creates a grid with the given width and height
     pub fn new(width: usize, height: usize) -> Grid {
         let mut rng = rand::thread_rng();
-        let mut cells = Vec::with_capacity(height);
+        let mut grid = Vec::with_capacity(height);
         for _ in 0..height {
-            let mut columns = Vec::with_capacity(width);
+            let mut row = Vec::with_capacity(width);
             for _ in 0..width {
                 let status = if rng.gen() {
                     Status::Alive
@@ -51,14 +51,16 @@ impl Grid {
                     Status::Dead
                 };
                 let cell = Cell(status);
-                columns.push(cell);
+                row.push(cell);
             }
-            cells.push(columns);
+            grid.push(row);
         }
+
+        let max_i = if height == 0 { 0 } else { height - 1 };
+        let max_j = if width == 0 { 0 } else { width - 1 };
+        let neighbours = neighbours(max_i, max_j, &grid);
+        let cells: Vec<Cell> = grid.into_iter().flat_map(|v| v).collect();
         let scratchpad_cells = cells.clone();
-        let (max_i, max_j) = max_coordinates(&cells);
-        let neighbours = neighbours(max_i, max_j, &cells);
-        let coords = coords(&cells);
         let area = width * height;
         Grid {
             cells,
@@ -66,7 +68,6 @@ impl Grid {
             max_i,
             max_j,
             area,
-            coords,
             neighbours,
         }
     }
@@ -76,15 +77,15 @@ impl Grid {
     ///
     /// TODO: is using iter faster or slower than just doing the checks?
     pub fn get_idx(&self, &GridIdx(idx): &GridIdx) -> Option<&Cell> {
-        if idx < self.coords.len() {
-            let coord = &self.coords[idx];
-            Some(&self.cells[coord.i][coord.j])
+        if idx < self.cells.len() {
+            Some(&self.cells[idx])
         } else {
             None
         }
     }
 
-    fn to_grid_idx(&self, &Coord { i, j }: &Coord) -> Option<GridIdx> {
+    // TODO delete if not used
+    pub fn to_grid_idx(&self, &Coord { i, j }: &Coord) -> Option<GridIdx> {
         if i <= self.max_i && j <= self.max_j {
             Some(GridIdx(self.width() * i + j))
         } else {
@@ -92,10 +93,12 @@ impl Grid {
         }
     }
 
-    fn to_coord(&self, &GridIdx(idx): &GridIdx) -> Option<Coord> {
+    // TODO delete if not used
+    pub fn to_coord(&self, &GridIdx(idx): &GridIdx) -> Option<Coord> {
         if idx < self.area() {
-            let i = idx / self.width();
-            let j = idx % self.width();
+            let width = self.width();
+            let i = idx / width;
+            let j = idx % width;
             Some(Coord { i, j })
         } else {
             None
@@ -103,8 +106,18 @@ impl Grid {
     }
 
     // Returns a slice with references to this grid's cells
-    pub fn cells(&self) -> &[Vec<Cell>] {
-        self.cells.as_slice()
+    pub fn cells(&self) -> Vec<Vec<&Cell>> {
+        let mut rows = Vec::with_capacity(self.height());
+        let mut i = 0;
+        for _ in 0 .. self.height() {
+            let mut columns = Vec::with_capacity(self.width());
+            for _ in 0 .. self.width() {
+                columns.push(&self.cells[i]);
+                i += 1;
+            }
+            rows.push(columns);
+        }
+        rows
     }
 
     pub fn height(&self) -> usize {
@@ -124,38 +137,27 @@ impl Grid {
             let neighbours = &self.neighbours;
             let last_gen = &self.cells;
             let area_requires_par = self.area() >= PAR_THRESHOLD_AREA;
-            let width_requires_par = self.width() >= PAR_THRESHOLD_LENGTH;
             let cells = &mut self.scratchpad_cells;
-            let cell_op = |(i, j, cell): (usize, usize, &mut Cell)| {
-                let alives = neighbours[i][j]
+            let cell_op = |(i, cell): (usize, &mut Cell)| {
+                let alives = neighbours[i]
                     .iter()
                     .fold(0,
-                          |acc, &Coord { i, j }| if last_gen[i][j].0 == Status::Alive {
+                          |acc, &GridIdx(idx)| if last_gen[idx].0 == Status::Alive {
                               acc + 1
                           } else {
                               acc
                           });
-                let next_status = last_gen[i][j].next_status(alives);
+                let next_status = last_gen[i].next_status(alives);
                 cell.update(next_status);
-            };
-            let non_par_row_op = |(i, row): (usize, &mut Vec<Cell>)| for (j, cell) in
-                row.iter_mut().enumerate() {
-                cell_op((i, j, cell))
             };
             if area_requires_par {
                 cells
                     .par_iter_mut()
                     .enumerate()
-                    .for_each(|(i, row)| if width_requires_par {
-                                  row.par_iter_mut()
-                                      .enumerate()
-                                      .for_each(|(j, cell)| cell_op((i, j, cell)))
-                              } else {
-                                  non_par_row_op((i, row))
-                              });
+                    .for_each(cell_op);
             } else {
-                for (i, row) in cells.iter_mut().enumerate() {
-                    non_par_row_op((i, row))
+                for (i, cell) in cells.iter_mut().enumerate() {
+                    cell_op((i, cell))
                 }
             }
         }
@@ -163,39 +165,23 @@ impl Grid {
     }
 }
 
-fn coords(cells: &[Vec<Cell>]) -> Vec<Coord> {
-    cells
-        .iter()
-        .enumerate()
-        .flat_map(|(i, row)| {
-                      let v: Vec<Coord> = row.iter()
-                          .enumerate()
-                          .map(|(j, _)| Coord { i, j })
-                          .collect();
-                      v
-                  })
-        .collect()
-}
+fn neighbours(max_i: usize, max_j: usize, cells: &[Vec<Cell>]) -> Vec<[GridIdx; 8]> {
+    let mut v = Vec::with_capacity((max_i+1) * (max_j + 1));
+    for (i, row) in cells.iter().enumerate() {
+        for (j, _) in row.iter().enumerate() {
+            let coord = Coord { i, j };
+            v.push(neighbour_coords(max_i, max_j, &coord))
+        }
 
-fn neighbours(max_i: usize, max_j: usize, cells: &[Vec<Cell>]) -> Vec<Vec<[Coord; 8]>> {
-    cells
-        .iter()
-        .enumerate()
-        .map(|(i, row)| {
-            row.iter()
-                .enumerate()
-                .map(|(j, _)| {
-                         let coord = Coord { i, j };
-                         neighbour_coords(max_i, max_j, &coord)
-                     })
-                .collect()
-        })
-        .collect()
+    }
+    v
 }
 
 // Given an i and j, returns the (maybe wrapped) coordinates of the neighbours of that
 // coordinate.
-fn neighbour_coords(max_i: usize, max_j: usize, coord: &Coord) -> [Coord; 8] {
+fn neighbour_coords(max_i: usize, max_j: usize, coord: &Coord) -> [GridIdx; 8] {
+    let width = max_j + 1;
+    let to_grid_idx = |Coord { i, j }: Coord| GridIdx(width * i + j);
     let Coord { i, j } = *coord;
 
     let i_up = match i {
@@ -234,16 +220,7 @@ fn neighbour_coords(max_i: usize, max_j: usize, coord: &Coord) -> [Coord; 8] {
     };
     let west = Coord { i, j: j_left };
     let north_west = Coord { i: i_up, j: j_left };
-    [north, north_east, east, south_east, south, south_west, west, north_west]
-}
-
-fn max_coordinates<A>(mat: &[Vec<A>]) -> (usize, usize) {
-    let max_i = mat.len() - 1;
-    let max_j = match mat.get(0) {
-        Some(r) => r.len() - 1,
-        None => 0,
-    };
-    (max_i, max_j)
+    [to_grid_idx(north), to_grid_idx(north_east), to_grid_idx(east), to_grid_idx(south_east), to_grid_idx(south), to_grid_idx(south_west), to_grid_idx(west), to_grid_idx(north_west)]
 }
 
 #[cfg(test)]
@@ -253,8 +230,8 @@ mod tests {
     #[test]
     fn test_grid_new() {
         let grid = Grid::new(10, 5);
-        assert_eq!(grid.cells.len(), 5);
-        assert_eq!(grid.cells[0].len(), 10);
+        assert_eq!(grid.cells().len(), 5);
+        assert_eq!(grid.cells()[0].len(), 10);
     }
 
     #[test]
@@ -268,32 +245,32 @@ mod tests {
          * [ (2,0) (2,1) (2,2) ]
          */
         let n0 = neighbour_coords(max_i, max_j, &Coord { i: 0, j: 0 });
-        assert_eq!(n0[0], Coord { i: 2, j: 0 }); // N
-        assert_eq!(n0[1], Coord { i: 2, j: 1 }); // NE
-        assert_eq!(n0[2], Coord { i: 0, j: 1 }); // E
-        assert_eq!(n0[3], Coord { i: 1, j: 1 }); // SE
-        assert_eq!(n0[4], Coord { i: 1, j: 0 }); // S
-        assert_eq!(n0[5], Coord { i: 1, j: 2 }); // SW
-        assert_eq!(n0[6], Coord { i: 0, j: 2 }); // W
-        assert_eq!(n0[7], Coord { i: 2, j: 2 }); // NW
+        assert_eq!(n0[0], grid.to_grid_idx(&Coord { i: 2, j: 0 }).unwrap()); // N
+        assert_eq!(n0[1], grid.to_grid_idx(&Coord { i: 2, j: 1 }).unwrap()); // NE
+        assert_eq!(n0[2], grid.to_grid_idx(&Coord { i: 0, j: 1 }).unwrap()); // E
+        assert_eq!(n0[3], grid.to_grid_idx(&Coord { i: 1, j: 1 }).unwrap()); // SE
+        assert_eq!(n0[4], grid.to_grid_idx(&Coord { i: 1, j: 0 }).unwrap()); // S
+        assert_eq!(n0[5], grid.to_grid_idx(&Coord { i: 1, j: 2 }).unwrap()); // SW
+        assert_eq!(n0[6], grid.to_grid_idx(&Coord { i: 0, j: 2 }).unwrap()); // W
+        assert_eq!(n0[7], grid.to_grid_idx(&Coord { i: 2, j: 2 }).unwrap()); // NW
         let n1 = neighbour_coords(max_i, max_j, &Coord { i: 1, j: 1 });
-        assert_eq!(n1[0], Coord { i: 0, j: 1 }); // N
-        assert_eq!(n1[1], Coord { i: 0, j: 2 }); // NE
-        assert_eq!(n1[2], Coord { i: 1, j: 2 }); // E
-        assert_eq!(n1[3], Coord { i: 2, j: 2 }); // SE
-        assert_eq!(n1[4], Coord { i: 2, j: 1 }); // S
-        assert_eq!(n1[5], Coord { i: 2, j: 0 }); // SW
-        assert_eq!(n1[6], Coord { i: 1, j: 0 }); // W
-        assert_eq!(n1[7], Coord { i: 0, j: 0 }); // NW
+        assert_eq!(n1[0], grid.to_grid_idx(&Coord { i: 0, j: 1 }).unwrap()); // N
+        assert_eq!(n1[1], grid.to_grid_idx(&Coord { i: 0, j: 2 }).unwrap()); // NE
+        assert_eq!(n1[2], grid.to_grid_idx(&Coord { i: 1, j: 2 }).unwrap()); // E
+        assert_eq!(n1[3], grid.to_grid_idx(&Coord { i: 2, j: 2 }).unwrap()); // SE
+        assert_eq!(n1[4], grid.to_grid_idx(&Coord { i: 2, j: 1 }).unwrap()); // S
+        assert_eq!(n1[5], grid.to_grid_idx(&Coord { i: 2, j: 0 }).unwrap()); // SW
+        assert_eq!(n1[6], grid.to_grid_idx(&Coord { i: 1, j: 0 }).unwrap()); // W
+        assert_eq!(n1[7], grid.to_grid_idx(&Coord { i: 0, j: 0 }).unwrap()); // NW
         let n2 = neighbour_coords(max_i, max_j, &Coord { i: 2, j: 2 });
-        assert_eq!(n2[0], Coord { i: 1, j: 2 }); // N
-        assert_eq!(n2[1], Coord { i: 1, j: 0 }); // NE
-        assert_eq!(n2[2], Coord { i: 2, j: 0 }); // E
-        assert_eq!(n2[3], Coord { i: 0, j: 0 }); // SE
-        assert_eq!(n2[4], Coord { i: 0, j: 2 }); // S
-        assert_eq!(n2[5], Coord { i: 0, j: 1 }); // SW
-        assert_eq!(n2[6], Coord { i: 2, j: 1 }); // W
-        assert_eq!(n2[7], Coord { i: 1, j: 1 }); // NW
+        assert_eq!(n2[0], grid.to_grid_idx(&Coord { i: 1, j: 2 }).unwrap()); // N
+        assert_eq!(n2[1], grid.to_grid_idx(&Coord { i: 1, j: 0 }).unwrap()); // NE
+        assert_eq!(n2[2], grid.to_grid_idx(&Coord { i: 2, j: 0 }).unwrap()); // E
+        assert_eq!(n2[3], grid.to_grid_idx(&Coord { i: 0, j: 0 }).unwrap()); // SE
+        assert_eq!(n2[4], grid.to_grid_idx(&Coord { i: 0, j: 2 }).unwrap()); // S
+        assert_eq!(n2[5], grid.to_grid_idx(&Coord { i: 0, j: 1 }).unwrap()); // SW
+        assert_eq!(n2[6], grid.to_grid_idx(&Coord { i: 2, j: 1 }).unwrap()); // W
+        assert_eq!(n2[7], grid.to_grid_idx(&Coord { i: 1, j: 1 }).unwrap()); // NW
     }
 
     // Just a test to make sure advance can run for a large number of iterations
@@ -315,7 +292,7 @@ mod tests {
                              vec![Cell(Status::Alive), Cell(Status::Dead), Cell(Status::Alive)],
                              vec![Cell(Status::Alive),
                                   Cell(Status::Alive),
-                                  Cell(Status::Alive)]];
+                                  Cell(Status::Alive)]].into_iter().flat_map(|v| v).collect();
         grid.cells = new_cells;
         assert_eq!(alive_count(&grid), 8)
     }
@@ -323,13 +300,13 @@ mod tests {
     #[test]
     fn test_get_idx() {
         let mut grid = Grid::new(3, 3);
-        let new_cells = vec![vec![Cell(Status::Alive),
+        let new_cells: Vec<Cell> = vec![vec![Cell(Status::Alive),
                                   Cell(Status::Alive),
                                   Cell(Status::Alive)],
                              vec![Cell(Status::Alive), Cell(Status::Dead), Cell(Status::Alive)],
                              vec![Cell(Status::Alive),
                                   Cell(Status::Alive),
-                                  Cell(Status::Alive)]];
+                                  Cell(Status::Alive)]].into_iter().flat_map(|v| v).collect();
         grid.cells = new_cells;
         for idx in 0..9 {
             let cell = grid.get_idx(&GridIdx(idx)).unwrap();
@@ -371,7 +348,7 @@ mod tests {
 
     fn alive_cells(grid: &Grid) -> Vec<Coord> {
         let mut v = vec![];
-        for (i, row) in grid.cells.iter().enumerate() {
+        for (i, row) in grid.cells().iter().enumerate() {
             for (j, cell) in row.iter().enumerate() {
                 if cell.alive() {
                     let coord = Coord { i, j };


### PR DESCRIPTION
~35% faster grid updating because we don't have to dereference twice (row, then column).

```
Before:

running 3 tests
test grid_1000x1000_advance_10_times ... bench:  46,540,732 ns/iter (+/- 9,468,205)
test grid_500x500_advance_10_times   ... bench:  13,165,339 ns/iter (+/- 1,746,717)
test grid_50x50_advance_50_times     ... bench:   2,309,584 ns/iter (+/- 521,540)

After:
running 3 tests
test grid_1000x1000_advance_10_times ... bench:  30,145,033 ns/iter (+/- 1,775,850)
test grid_500x500_advance_10_times   ... bench:   8,656,586 ns/iter (+/- 1,088,516)
test grid_50x50_advance_50_times     ... bench:   1,411,911 ns/iter (+/- 262,043)
```