### PR TITLE
Move instance updating into update_instances method

### DIFF
--- a/benches/rendering_benchmark.rs
+++ b/benches/rendering_benchmark.rs
@@ -8,28 +8,28 @@ use gol::rendering::*;
 use test::Bencher;
 
 #[bench]
-fn render_50x50_grid_10times(b: &mut Bencher) {
+fn update_instances_50x50_grid_10times(b: &mut Bencher) {
     let grid = Grid::new(50, 50);
     let mut app = App::new(grid, 1024, 768, 30);
     b.iter(|| for _ in 0..10 {
-               app.render()
+               app.update_instances()
            })
 }
 
 #[bench]
-fn render_500x500_grid_10times(b: &mut Bencher) {
+fn update_instances_500x500_grid_10times(b: &mut Bencher) {
     let grid = Grid::new(500, 500);
     let mut app = App::new(grid, 1024, 768, 30);
     b.iter(|| for _ in 0..10 {
-               app.render()
+               app.update_instances()
            })
 }
 
 #[bench]
-fn render_1000x1000_grid_10times(b: &mut Bencher) {
+fn update_instances_1000x1000_grid_10times(b: &mut Bencher) {
     let grid = Grid::new(1000, 1000);
     let mut app = App::new(grid, 1024, 768, 30);
     b.iter(|| for _ in 0..10 {
-               app.render()
+               app.update_instances()
            })
 }


### PR DESCRIPTION
Rewrite benchmarks to benchmark update_instances() instead because
we don't have much control over the other stuff that comes from gfx-rs.

This also helps us keep the time the lock on `Arc<Mutex<Grid>>` is held 
as short as possible.